### PR TITLE
Aes native ciphers

### DIFF
--- a/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesBufferCipher.kt
+++ b/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesBufferCipher.kt
@@ -1,0 +1,59 @@
+package com.island.yoshiz.mpp.krypto.aes.ciphers
+
+import com.island.yoshiz.mpp.krypto.aes.model.buffer.AesEncryptedData
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding
+import com.island.yoshiz.mpp.krypto.common.Operation
+import com.island.yoshiz.mpp.krypto.common.Operation.DECRYPT
+import com.island.yoshiz.mpp.krypto.common.Operation.ENCRYPT
+
+/**
+ * Implements the actual operation of encryption and decryption for AES transformation on a buffer.
+ * The underlying AES transformation is delegated to an [AesNativeCipher] instance
+ */
+internal class AesBufferCipher constructor(
+        keyLength: AesKeysLength,
+        mode: AesBlockMode,
+        padding: Padding?
+) {
+
+    private var cipher = AesNativeCipher(keyLength, mode, padding)
+
+    /**
+     * Performs the AES decryption according to parameters passed at construction time
+     * This consider that the content of [dataToDecrypt] is valid. Checks must be performed before
+     * this method is called.
+     */
+    fun decrypt(
+            dataToDecrypt: ByteArray,
+            iv: ByteArray,
+            aesKey: ByteArray
+    ): ByteArray {
+        return performBufferOperation(dataToDecrypt, iv, aesKey, DECRYPT)
+    }
+
+    /**
+     * Performs the AES encryption according to parameters passed at construction time
+     * This will return a valid instance of [AesEncryptedData]
+     */
+    fun encrypt(
+            dataToEncrypt: ByteArray,
+            iv: ByteArray,
+            aesKey: ByteArray
+    ): ByteArray {
+        return performBufferOperation(dataToEncrypt, iv, aesKey, ENCRYPT)
+    }
+
+    private fun performBufferOperation(
+            data: ByteArray,
+            iv: ByteArray,
+            aesKey: ByteArray,
+            operation: Operation
+    ): ByteArray {
+        cipher.init(iv, aesKey, operation)
+        val update = cipher.update(data, 0, data.size)
+        val finalised = cipher.finalise()
+        return update + finalised
+    }
+}

--- a/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesFileCipher.kt
+++ b/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesFileCipher.kt
@@ -1,0 +1,208 @@
+package com.island.yoshiz.mpp.krypto.aes.ciphers
+
+import com.island.yoshiz.mpp.krypto.aes.model.buffer.AesEncryptedData
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesException
+import com.island.yoshiz.mpp.krypto.common.Operation
+import com.island.yoshiz.mpp.krypto.common.Operation.DECRYPT
+import com.island.yoshiz.mpp.krypto.common.Operation.ENCRYPT
+import com.island.yoshiz.mpp.krypto.common.model.files.File
+import com.island.yoshiz.mpp.krypto.common.model.streams.InputStream
+import com.island.yoshiz.mpp.krypto.common.model.streams.OutputStream
+import com.island.yoshiz.mpp.krypto.common.utils.getInputStreamForCipher
+import com.island.yoshiz.mpp.krypto.common.utils.getOutputStream
+import com.island.yoshiz.mpp.krypto.common.utils.getOutputStreamForCipher
+import com.island.yoshiz.mpp.krypto.common.utils.getTempFileName
+
+/**
+ * Implements the actual operation of encryption and decryption for AES transformation on a file.
+ * The underlying AES transformation is delegated to an [AesNativeCipher] instance
+ */
+internal class AesFileCipher constructor(
+        keyLength: AesKeysLength,
+        private val mode: AesBlockMode,
+        padding: Padding?
+) {
+
+    private var cipher = AesNativeCipher(keyLength, mode, padding)
+
+    /**
+     * Performs the AES decryption according to parameters passed at construction time
+     * This consider that the content of [pathToFile] is valid. Checks must be performed before
+     * this method is called.
+     *
+     * @param pathToFile the path to the file to decrypt
+     * @param iv the initialisation vector
+     * @param aesKey the encryption key material
+     * @param replaceOriginal true: the original file located at [pathToFile] will be replaced with
+     * its decrypted version. False, the original file will be kept unchanged.
+     * @param expectIvInFile true if the IV is expected to be in the encrypted file. If so it will be persisted
+     * at the beginning: $ivSize $iv $encryptedFileContent
+     * @return the path to the decrypted file. if [replaceOriginal] is true, this will the same
+     * value as [pathToFile]
+     */
+    fun decrypt(
+            pathToFile: String,
+            iv: ByteArray,
+            aesKey: ByteArray,
+            replaceOriginal: Boolean,
+            expectIvInFile: Boolean
+    ): String {
+        return performFileOperation(
+                pathToFile,
+                iv,
+                aesKey,
+                DECRYPT,
+                replaceOriginal,
+                expectIvInFile
+        )
+    }
+
+    /**
+     * Performs the AES encryption according to parameters passed at construction time
+     * This will return a valid instance of [AesEncryptedData]
+     *
+     * @param pathToFile the path to the file to encrypt
+     * @param iv the initialisation vector
+     * @param aesKey the encryption key material
+     * @param replaceOriginal true: the original file located at [pathToFile] will be replaced with
+     * its encrypted version. False, the original file will be kept unchanged.
+     * @param expectIvInFile true if the IV is expected to be in the encrypted file. If so it will be persisted
+     * at the beginning: $ivSize $iv $encryptedFileContent
+     * @return the path to the encrypted file. if [replaceOriginal] is true, this will the same
+     * value as [pathToFile]
+     */
+    fun encrypt(
+            pathToFile: String,
+            iv: ByteArray,
+            aesKey: ByteArray,
+            replaceOriginal: Boolean,
+            expectIvInFile: Boolean
+    ): String {
+        return performFileOperation(
+                pathToFile,
+                iv,
+                aesKey,
+                ENCRYPT,
+                replaceOriginal,
+                expectIvInFile
+        )
+    }
+
+    private fun performFileOperation(
+            pathToFile: String,
+            iv: ByteArray?,
+            key: ByteArray,
+            operation: Operation,
+            replaceOriginal: Boolean,
+            expectIvInFile: Boolean
+    ): String {
+
+        var inputStream: InputStream? = null
+        var outputStream: OutputStream? = null
+        var actualIv = iv
+
+        val tempFilePath = getTempFileName(pathToFile, operation)
+
+        val sourceFile = File(pathToFile)
+        if (sourceFile.exists().not()) {
+            throw AesException("The file '$pathToFile' doesn't exist, operation = $operation")
+        }
+
+        try {
+
+            inputStream = getInputStreamForCipher(pathToFile, operation, cipher)
+            outputStream = getOutputStreamForCipher(tempFilePath, operation, cipher)
+
+            if (expectIvInFile) {
+                // IV needs to be written in clear
+                actualIv =
+                        processExpectedIvInFile(operation, actualIv, tempFilePath, inputStream)
+            }
+
+            // Cipher needs to be properly initialised before(!) starting to use it
+            cipher.init(actualIv!!, key, operation)
+
+            readWriteCipheredStream(inputStream, outputStream)
+
+            // Delete clear file, and renamed encrypted to the old file name
+            val destinationFile = File(tempFilePath)
+            return if (replaceOriginal) {
+
+                replaceSourceFile(sourceFile, destinationFile)
+            } else {
+                destinationFile.getAbsolutePath()
+            }
+        } finally {
+            inputStream?.close()
+            outputStream?.close()
+        }
+    }
+
+    private fun readWriteCipheredStream(inputStream: InputStream, outputStream: OutputStream) {
+        val buffer = ByteArray(1024 * 1024)
+
+        // Loop that will read from the input stream and then write to the output stream
+        var read = inputStream.read(buffer)
+        while (read > 0) {
+
+            outputStream.write(buffer, 0, read)
+
+            // read next chunk from the file
+            read = inputStream.read(buffer)
+        }
+
+        outputStream.flush()
+    }
+
+    /**
+     * @param operation the current operation : [ENCRYPT] or [DECRYPT]
+     * @param iv in case of an [ENCRYPT] operation and the IV is
+     * expected to be NON null and will be written in [filePathToWriteTo]. If the operation is
+     * [DECRYPT] the iv will be read from the [inputStream]
+     */
+    private fun processExpectedIvInFile(
+            operation: Operation,
+            iv: ByteArray?,
+            filePathToWriteTo: String,
+            inputStream: InputStream
+    ): ByteArray? {
+        var actualIv = iv
+
+        if (operation == ENCRYPT) {
+            val clearOutputStream = getOutputStream(filePathToWriteTo)
+            clearOutputStream.write(iv!!, 0, iv.size)
+            clearOutputStream.flush()
+            clearOutputStream.close()
+        } else if (operation == DECRYPT) {
+            actualIv = ByteArray(mode.ivLengthBytes)
+            inputStream.read(actualIv)
+        }
+
+        return actualIv
+    }
+
+    /**
+     * Replace [source] with [destination] and returns the path of the new file which is now source
+     */
+    private fun replaceSourceFile(source: File, destination: File): String {
+        // Delete clear file, and renamed encrypted to the old file name
+
+        if (!source.delete()) {
+            throw AesException("Unable to remove ${source.getAbsolutePath()}")
+        }
+
+        if (!destination.renameTo(source)) {
+            throw AesException(
+                    "Unable to move the destination file from '${source.getAbsolutePath()}' to " +
+                            "'${destination.getAbsolutePath()}'"
+            )
+        }
+
+        return source.getAbsolutePath()
+    }
+}
+
+private const val TAG = "FileCipher"

--- a/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesNativeCipher.kt
+++ b/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesNativeCipher.kt
@@ -1,0 +1,15 @@
+package com.island.yoshiz.mpp.krypto.aes.ciphers
+
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding
+import com.island.yoshiz.mpp.krypto.common.NativeCipher
+
+/**
+ * This class will be implementing the native cryptographic function for each platform
+ */
+internal expect class AesNativeCipher(
+        keyLength: AesKeysLength,
+        mode: AesBlockMode,
+        padding: Padding?
+) : NativeCipher

--- a/aes/src/commonTest/kotlin/com/island/yoshiz/mpp/krypto/aes/TestConstants.kt
+++ b/aes/src/commonTest/kotlin/com/island/yoshiz/mpp/krypto/aes/TestConstants.kt
@@ -1,0 +1,19 @@
+package com.island.yoshiz.mpp.krypto
+
+const val ENCRYPTION_KEY_B64 = "ZyTwtcxfq3db9DSEYtVPwfPz1AcW4l7JBf997UB7qLg="
+const val IV_B64 = "vvtoafrxIA5gjdlOv81O7Q=="
+
+const val MESSAGE_LONG = "Don't try to read this text. Top Secret Stuff"
+const val MESSAGE_LONG_ENCRYPTED_B64 =
+        "moWgSZ6oPuDLQ9laAvLmjhYK2tuzLqEFVGlkeZ6Md1C3/N9KPPbNNuzAGk2W9PD9"
+
+const val MESSAGE_BELOW_BLOCK_SIZE = "Just Don't"
+const val MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64 = "9m232g31HbfohFMlPcx62A=="
+
+const val MESSAGE_REALLY_LONG =
+        "Don't try to read this text. Top Secret Stuff that needs to be long" +
+                " enough so that the encrypted result is more than 2 blocs long."
+const val MESSAGE_REALLY_LONG_ENCRYPTED_B64 =
+        "moWgSZ6oPuDLQ9laAvLmjhYK2tuzLqEFVGlkeZ6Md1APhXoy22YH" +
+                "JyiwSOqM1S3iE2GfDADW079SIgP4/mzuzBzB6EmOU5exSpy0Rb6sPoiSVCMIilYx2+OfnrsZS4j3AFJVTyx1zXyqQLd" +
+                "Mn+YsyhNdD8wkres7jwM0p3hQk6oOAm6rDyRRJFNsP5Mo4yvJ"

--- a/aes/src/commonTest/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesBufferCipherTest.kt
+++ b/aes/src/commonTest/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesBufferCipherTest.kt
@@ -1,0 +1,83 @@
+package com.island.yoshiz.mpp.krypto.aes.ciphers
+
+import com.island.yoshiz.mpp.krypto.ENCRYPTION_KEY_B64
+import com.island.yoshiz.mpp.krypto.IV_B64
+import com.island.yoshiz.mpp.krypto.MESSAGE_BELOW_BLOCK_SIZE
+import com.island.yoshiz.mpp.krypto.MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64
+import com.island.yoshiz.mpp.krypto.MESSAGE_LONG
+import com.island.yoshiz.mpp.krypto.MESSAGE_LONG_ENCRYPTED_B64
+import com.island.yoshiz.mpp.krypto.MESSAGE_REALLY_LONG
+import com.island.yoshiz.mpp.krypto.MESSAGE_REALLY_LONG_ENCRYPTED_B64
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesConfiguration.AES_CBC_PKCS7_256
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKeyIv
+import com.island.yoshiz.mpp.krypto.common.utils.Base64Factory
+import com.island.yoshiz.mpp.krypto.common.utils.extensions.byteToCharArray
+import kotlin.test.*
+
+@ExperimentalStdlibApi
+class AesBufferCipherTest {
+
+    private val aesConf = AES_CBC_PKCS7_256
+    private val base64Engine = Base64Factory.createEngine()
+    private val keyIv = AesKeyIv(
+            base64Engine.decode(IV_B64),
+            base64Engine.decode(ENCRYPTION_KEY_B64)
+    )
+
+    private lateinit var bufferCipher: AesBufferCipher
+
+    @BeforeTest
+    fun setup() {
+        bufferCipher = AesBufferCipher(aesConf.keyLength, aesConf.mode, aesConf.padding)
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andShortText_thenEncryptionSuccess() {
+        performEncryptionAndAssert(MESSAGE_BELOW_BLOCK_SIZE, MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64)
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andLongText_thenEncryptionSuccess() {
+        performEncryptionAndAssert(MESSAGE_LONG, MESSAGE_LONG_ENCRYPTED_B64)
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andReallyLongText_thenEncryptionSuccess() {
+        performEncryptionAndAssert(MESSAGE_REALLY_LONG, MESSAGE_REALLY_LONG_ENCRYPTED_B64)
+    }
+
+    private fun performEncryptionAndAssert(clearText: String, encryptedTextB64: String) {
+        val encrypted = bufferCipher.encrypt(
+                clearText.encodeToByteArray(),
+                keyIv.iv.data,
+                keyIv.aesKey.material
+        )
+
+        val encryptedBase64 = base64Engine.encode(encrypted).byteToCharArray()
+
+        assertEquals(encryptedTextB64, String(encryptedBase64))
+    }
+
+    @Test
+    fun testDecrypt_givenAES_CBC_PKCS7_256_andShortEncryptedText_thenDecryptionSuccess() {
+        performDecryptionAndAssert(MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64, MESSAGE_BELOW_BLOCK_SIZE)
+    }
+
+    @Test
+    fun testDecrypt_givenAES_CBC_PKCS7_256_andLongEncryptedText_thenDecryptionSuccess() {
+        performDecryptionAndAssert(MESSAGE_LONG_ENCRYPTED_B64, MESSAGE_LONG)
+    }
+
+    @Test
+    fun testDecrypt_givenAES_CBC_PKCS7_256_andReallyLongEncryptedText_thenDecryptionSuccess() {
+        performDecryptionAndAssert(MESSAGE_REALLY_LONG_ENCRYPTED_B64, MESSAGE_REALLY_LONG)
+    }
+
+    private fun performDecryptionAndAssert(encryptedTextB64: String, clearText: String) {
+        val encrypted = base64Engine.decode(encryptedTextB64)
+
+        val decrypted = bufferCipher.decrypt(encrypted, keyIv.iv.data, keyIv.aesKey.material)
+
+        assertEquals(clearText, String(decrypted.byteToCharArray()))
+    }
+}

--- a/aes/src/commonTest/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesFileCipherTest.kt
+++ b/aes/src/commonTest/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesFileCipherTest.kt
@@ -1,0 +1,208 @@
+package com.island.yoshiz.mpp.krypto.aes.ciphers
+
+import com.island.yoshiz.mpp.krypto.ENCRYPTION_KEY_B64
+import com.island.yoshiz.mpp.krypto.IV_B64
+import com.island.yoshiz.mpp.krypto.MESSAGE_BELOW_BLOCK_SIZE
+import com.island.yoshiz.mpp.krypto.MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64
+import com.island.yoshiz.mpp.krypto.MESSAGE_LONG
+import com.island.yoshiz.mpp.krypto.MESSAGE_LONG_ENCRYPTED_B64
+import com.island.yoshiz.mpp.krypto.MESSAGE_REALLY_LONG
+import com.island.yoshiz.mpp.krypto.MESSAGE_REALLY_LONG_ENCRYPTED_B64
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesConfiguration.AES_CBC_PKCS7_256
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKeyIv
+import com.island.yoshiz.mpp.krypto.common.model.files.File
+import com.island.yoshiz.mpp.krypto.common.model.streams.FileInputStream
+import com.island.yoshiz.mpp.krypto.common.model.streams.FileOutputStream
+import com.island.yoshiz.mpp.krypto.common.utils.Base64Factory
+import kotlin.test.*
+
+@ExperimentalStdlibApi
+internal class AesFileCipherTest {
+
+    private val testFileClear = File("aes_encryption_test.decrypted.txt")
+    private val testFileEncrypted = File("aes_encryption_test.encrypted.txt")
+
+    private val aesConf = AES_CBC_PKCS7_256
+    private val base64Engine = Base64Factory.createEngine()
+    private val aesKeyIv = AesKeyIv(
+            base64Engine.decode(IV_B64),
+            base64Engine.decode(ENCRYPTION_KEY_B64)
+    )
+
+    private lateinit var fileCipher: AesFileCipher
+    private lateinit var tempFilePath: String
+
+    @BeforeTest
+    fun setup() {
+        fileCipher = AesFileCipher(aesConf.keyLength, aesConf.mode, aesConf.padding)
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andShortLongText_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_BELOW_BLOCK_SIZE, MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64,
+                replaceFile = false,
+                persistIv = false
+        )
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andLongText_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_LONG, MESSAGE_LONG_ENCRYPTED_B64,
+                replaceFile = false,
+                persistIv = false
+        )
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andReallyLongText_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_REALLY_LONG, MESSAGE_REALLY_LONG_ENCRYPTED_B64,
+                replaceFile = false,
+                persistIv = false
+        )
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andShortLongText_andReplaceOriginal_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_BELOW_BLOCK_SIZE, MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64,
+                replaceFile = true,
+                persistIv = false
+        )
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andLongText_andReplaceOriginal_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_LONG, MESSAGE_LONG_ENCRYPTED_B64,
+                replaceFile = true,
+                persistIv = false
+        )
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andReallyLongText_andReplaceOriginal_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_REALLY_LONG, MESSAGE_REALLY_LONG_ENCRYPTED_B64,
+                replaceFile = true,
+                persistIv = false
+        )
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andShortLongText_andPersistIv_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_BELOW_BLOCK_SIZE, MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64,
+                replaceFile = false,
+                persistIv = true
+        )
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andLongText_andPersistIv_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_LONG, MESSAGE_LONG_ENCRYPTED_B64,
+                replaceFile = false,
+                persistIv = true
+        )
+    }
+
+    @Test
+    fun testEncrypt_givenAES_CBC_PKCS7_256_andReallyLongText_andPersistIv_thenEncryptionSuccess() {
+        testEncrypt(MESSAGE_REALLY_LONG, MESSAGE_REALLY_LONG_ENCRYPTED_B64,
+                replaceFile = false,
+                persistIv = true
+        )
+    }
+
+    private fun testEncrypt(
+            messageClear: String, messageEncrypted: String,
+            replaceFile: Boolean, persistIv: Boolean
+    ) {
+        prepareClearFile(messageClear.encodeToByteArray())
+
+        tempFilePath = fileCipher.encrypt(
+                testFileClear.getAbsolutePath(),
+                aesKeyIv.iv.data,
+                aesKeyIv.aesKey.material,
+                replaceFile,
+                persistIv
+        )
+
+        // check that the return files contains the encrypted content
+        val buffer = ByteArray(1024)
+        val encryptedStream = FileInputStream(File(tempFilePath))
+        val sizeRead = encryptedStream.read(buffer)
+        val result = buffer.copyOf(sizeRead)
+
+        assertTrue {
+            base64Engine
+                    .decode(messageEncrypted)
+                    .contentEquals(result)
+        }
+    }
+
+    @Test
+    fun testDecrypt_givenAES_CBC_PKCS7_256_andShortText_thenDecryptSuccess() {
+        testDecrypt(MESSAGE_BELOW_BLOCK_SIZE, MESSAGE_BELOW_BLOCK_SIZE_ENCRYPTED_B64,
+                replaceFile = false,
+                persistedIv = false
+        )
+    }
+
+    @Test
+    fun testDecrypt_givenAES_CBC_PKCS7_256_andLongText_thenDecryptSuccess() {
+        testDecrypt(MESSAGE_LONG, MESSAGE_LONG_ENCRYPTED_B64,
+                replaceFile = false,
+                persistedIv = false
+        )
+    }
+
+    @Test
+    fun testDecrypt_givenAES_CBC_PKCS7_256_andReallyLongText_thenDecryptSuccess() {
+        testDecrypt(MESSAGE_REALLY_LONG, MESSAGE_REALLY_LONG_ENCRYPTED_B64,
+                replaceFile = false,
+                persistedIv = false
+        )
+    }
+
+    private fun testDecrypt(
+            clearMessage: String, encryptedMessage: String,
+            replaceFile: Boolean, persistedIv: Boolean
+    ) {
+        prepareEncryptedFile(base64Engine.decode(encryptedMessage))
+
+        tempFilePath = fileCipher.decrypt(
+                testFileEncrypted.getAbsolutePath(),
+                aesKeyIv.iv.data,
+                aesKeyIv.aesKey.material,
+                replaceFile,
+                persistedIv
+        )
+
+        // check that the return files contains the decrypted content
+        val buffer = ByteArray(1024)
+        val decryptedStream = FileInputStream(File(tempFilePath))
+        val sizeRead = decryptedStream.read(buffer)
+        val result = buffer.copyOf(sizeRead)
+
+        assertTrue {
+            clearMessage.encodeToByteArray().contentEquals(result)
+        }
+    }
+
+    private fun prepareClearFile(messageClear: ByteArray) {
+        val testFileStream = FileOutputStream(testFileClear)
+        testFileStream.write(messageClear, 0, messageClear.size)
+        testFileStream.flush()
+        testFileStream.close()
+    }
+
+    private fun prepareEncryptedFile(messageEncrypted: ByteArray) {
+        val testFileEncrypted = FileOutputStream(testFileEncrypted)
+        testFileEncrypted.write(messageEncrypted, 0, messageEncrypted.size)
+        testFileEncrypted.flush()
+        testFileEncrypted.close()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        testFileClear.delete()
+        testFileEncrypted.delete()
+        File(tempFilePath).delete()
+    }
+}

--- a/aes/src/iosMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesNativeCipher.kt
+++ b/aes/src/iosMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesNativeCipher.kt
@@ -1,0 +1,246 @@
+package com.island.yoshiz.mpp.krypto.aes.ciphers
+
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode.CBC
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode.CTR
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode.GCM
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength.Aes128
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength.Aes192
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength.Aes256
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding.PKCS5
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding.PKCS7
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesDecryptionException
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesEncryptionException
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesException
+import com.island.yoshiz.mpp.krypto.common.NativeCipher
+import com.island.yoshiz.mpp.krypto.common.Operation
+import com.island.yoshiz.mpp.krypto.common.Operation.DECRYPT
+import com.island.yoshiz.mpp.krypto.common.Operation.ENCRYPT
+import com.island.yoshiz.mpp.krypto.common.model.exceptions.CipherException
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.refTo
+import kotlinx.cinterop.toCValues
+import kotlinx.cinterop.value
+import platform.CoreCrypto.CCCryptorCreateWithMode
+import platform.CoreCrypto.CCCryptorFinal
+import platform.CoreCrypto.CCCryptorGetOutputLength
+import platform.CoreCrypto.CCCryptorRefVar
+import platform.CoreCrypto.CCCryptorRelease
+import platform.CoreCrypto.CCCryptorUpdate
+import platform.CoreCrypto.ccNoPadding
+import platform.CoreCrypto.kCCAlgorithmAES
+import platform.CoreCrypto.kCCBlockSizeAES128
+import platform.CoreCrypto.kCCDecrypt
+import platform.CoreCrypto.kCCEncrypt
+import platform.CoreCrypto.kCCKeySizeAES128
+import platform.CoreCrypto.kCCKeySizeAES192
+import platform.CoreCrypto.kCCKeySizeAES256
+import platform.CoreCrypto.kCCModeCBC
+import platform.CoreCrypto.kCCModeCTR
+import platform.CoreCrypto.kCCOptionPKCS7Padding
+import platform.CoreCrypto.kCCSuccess
+import platform.darwin.nil
+import platform.posix.memcpy
+import platform.posix.size_t
+import platform.posix.size_tVar
+
+@ExperimentalUnsignedTypes
+internal actual class AesNativeCipher actual constructor(
+        private val keyLength: AesKeysLength,
+        private val mode: AesBlockMode,
+        private val padding: Padding?
+) : NativeCipher {
+
+    private lateinit var cryptor: CCCryptorRefVar
+    private lateinit var cryptOperation: Operation
+    private var expectedLength: size_t = 0.convert()
+    private var _isInitiliased = false
+
+    /**
+     * Initialise internal structures with the key and iv submitted
+     * This method must be called first
+     */
+    override fun init(
+            iv: ByteArray, aesKey: ByteArray,
+            operation: Operation
+    ) {
+
+        cryptOperation = operation
+        cryptor = nativeHeap.alloc()
+
+        // Initialise with the required mode
+        val cryptStatus = CCCryptorCreateWithMode(
+                getCipherMode(operation),
+                modeConstant,
+                kCCAlgorithmAES,
+                paddingConstant,
+                iv.toCValues(),
+                aesKey.toCValues(),
+                keyLengthConstant.convert(),
+                nil,
+                0,
+                0,
+                0,
+                cryptor.ptr
+        )
+
+        if (cryptStatus != kCCSuccess) {
+            throw getAesException(operation, "Unable to create the crypto cipher : $cryptStatus")
+        } else {
+            _isInitiliased = true
+        }
+    }
+
+    /**
+     * Update the current cipher with the next bunch of data.
+     * If the data length is less than the block size then the returned buffer will be empty
+     */
+    override fun update(data: ByteArray, offset: Int, size: Int): ByteArray = memScoped {
+        checkInit()
+
+        expectedLength = CCCryptorGetOutputLength(
+                cryptor.value,
+                data.size.convert(),
+                true // include the required size for the update and for the finalise call
+        )
+
+        val buffer = allocArray<ByteVar>(expectedLength.convert())
+        val writtenUpdate = alloc<size_tVar>()
+
+        // Update with the current input.
+        val cryptStatus = CCCryptorUpdate(
+                cryptor.value,
+                data.copyOfRange(offset, offset + size).toCValues(),
+                size.convert(),
+                buffer,
+                expectedLength.convert(),
+                writtenUpdate.ptr
+        )
+
+        if (cryptStatus == kCCSuccess) {
+            val written = writtenUpdate.value
+            val result = ByteArray(written.convert())
+
+            // Only copy if there is something to copy otherwise memcpy will crash with kotlin.ArrayIndexOutOfBoundsException
+            if (written > 0.convert()) {
+                memcpy(result.refTo(0), buffer, written)
+            }
+
+            // update the remaining length for the allocation for the finalise call
+            expectedLength -= written
+
+            return@memScoped result
+        }
+
+        throw getAesException(
+                cryptOperation, "Unable to update the current buffer: $cryptStatus, " +
+                "data read: ${writtenUpdate.value}"
+        )
+    }
+
+    /**
+     * Finalise a multipart operation. return the data left not returned by [update]
+     */
+    override fun finalise(): ByteArray = memScoped {
+        checkInit()
+
+        val buffer = allocArray<ByteVar>(expectedLength.convert())
+        val writtenFinal = alloc<size_tVar>()
+
+        // Finalising to get the rest of the data
+        val cryptStatus = CCCryptorFinal(
+                cryptor.value,
+                buffer,
+                expectedLength,
+                writtenFinal.ptr
+        )
+
+        CCCryptorRelease(cryptor.value)
+        nativeHeap.free(cryptor.rawPtr)
+
+        if (cryptStatus == kCCSuccess) {
+            val writtenTotal = writtenFinal.value
+            val result = ByteArray(writtenTotal.convert())
+            memcpy(result.refTo(0), buffer, writtenTotal)
+
+            _isInitiliased = false
+            return@memScoped result
+        }
+
+        throw getAesException(cryptOperation, "Unable to finalise the crypto cipher : $cryptStatus")
+    }
+
+    override fun getOutputSize(inputLength: Int): Int {
+        val size = CCCryptorGetOutputLength(
+                cryptor.value,
+                inputLength.convert(),
+                true
+        )
+
+        return size.convert()
+    }
+
+    private fun checkInit() {
+        if (_isInitiliased.not()) {
+            throw CipherException("The cipher has not been initialised. Call init")
+        }
+    }
+
+    private fun getAesException(operation: Operation, msg: String): AesException {
+        val conf = "AES/$mode/$padding/$keyLength"
+        return if (operation == ENCRYPT) {
+            AesEncryptionException("Encrypt[$conf] - $msg")
+        } else {
+            AesDecryptionException("Decrypt[$conf] - $msg")
+        }
+    }
+
+    private val keyLengthConstant: UInt
+        get() {
+            return when (keyLength) {
+                Aes128 -> kCCKeySizeAES128
+                Aes192 -> kCCKeySizeAES192
+                Aes256 -> kCCKeySizeAES256
+            }
+        }
+
+    private val paddingConstant: UInt
+        get() {
+            return when (padding) {
+                PKCS5 -> kCCOptionPKCS7Padding
+                PKCS7 -> kCCOptionPKCS7Padding
+                null -> ccNoPadding
+            }
+        }
+
+    private val modeConstant: UInt
+        get() {
+            return when (mode) {
+                CBC -> kCCModeCBC
+                CTR -> kCCModeCTR
+                GCM -> TODO()
+            }
+        }
+
+    private fun getCipherMode(operation: Operation): UInt {
+        return when (operation) {
+            DECRYPT -> kCCDecrypt
+            ENCRYPT -> kCCEncrypt
+        }
+    }
+
+    private fun getPaddingLength(operation: Operation): UInt {
+        return when (operation) {
+            DECRYPT -> 0.toUInt()
+            ENCRYPT -> kCCBlockSizeAES128
+        }
+    }
+}

--- a/aes/src/jvmMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesNativeCipher.kt
+++ b/aes/src/jvmMain/kotlin/com/island/yoshiz/mpp/krypto/aes/ciphers/AesNativeCipher.kt
@@ -1,0 +1,138 @@
+package com.island.yoshiz.mpp.krypto.aes.ciphers
+
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode.CBC
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode.CTR
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode.GCM
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding.PKCS5
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding.PKCS7
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesDecryptionException
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesEncryptionException
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesException
+import com.island.yoshiz.mpp.krypto.common.NativeCipher
+import com.island.yoshiz.mpp.krypto.common.Operation
+import com.island.yoshiz.mpp.krypto.common.Operation.DECRYPT
+import com.island.yoshiz.mpp.krypto.common.Operation.ENCRYPT
+import com.island.yoshiz.mpp.krypto.common.model.exceptions.CipherException
+import java.security.GeneralSecurityException
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+internal actual class AesNativeCipher actual constructor(
+        private val keyLength: AesKeysLength,
+        private val mode: AesBlockMode,
+        private val padding: Padding?
+) : NativeCipher {
+
+    private lateinit var cipher: Cipher
+    private lateinit var operation: Operation
+    private var _isInitiliased = false
+
+    /**
+     * Initialise internal structures with the key and iv submitted
+     * This method must be called first
+     */
+    override fun init(
+            iv: ByteArray,
+            aesKey: ByteArray,
+            operation: Operation
+    ) {
+        this.operation = operation
+        cipher = generateAESCBCCipherAr(iv, aesKey)
+        _isInitiliased = true
+    }
+
+    /**
+     * Update the current cipher with the next bunch of data.
+     * If the data length is less than the block size then the returned buffer will be empty
+     */
+    override fun update(data: ByteArray, offset: Int, size: Int): ByteArray {
+        checkInit()
+
+        try {
+            return cipher.update(data, offset, size)
+        } catch (exception: GeneralSecurityException) {
+            throw getAesException("Unable to update the cipher", exception)
+        }
+    }
+
+    /**
+     * Finalise a multipart operation. return the data left not returned by [update]
+     */
+    override fun finalise(): ByteArray {
+        checkInit()
+
+        try {
+            val finalised: ByteArray? = cipher.doFinal()
+            _isInitiliased = false
+            return finalised ?: ByteArray(0)
+        } catch (exception: GeneralSecurityException) {
+            throw getAesException("Unable to finalise", exception)
+        }
+    }
+
+    override fun getOutputSize(inputLength: Int): Int {
+        checkInit()
+
+        return cipher.getOutputSize(inputLength)
+    }
+
+    private fun checkInit() {
+        if (_isInitiliased.not()) {
+            throw CipherException("The cipher has not been initialised. Call init")
+        }
+    }
+
+    private fun generateAESCBCCipherAr(iv: ByteArray, key: ByteArray): Cipher {
+        try {
+            val mode = getCipherMode(operation)
+            val cipher = Cipher.getInstance(aesTransformation)
+            val ivSpec = IvParameterSpec(iv)
+            val secretKeySpec = SecretKeySpec(key, "AES")
+            cipher.init(mode, secretKeySpec, ivSpec)
+
+            return cipher
+        } catch (exception: GeneralSecurityException) {
+            throw getAesException("Unable to create the native cipher", exception)
+        }
+    }
+
+    private fun getAesException(msg: String, cause: Throwable): AesException {
+        val conf = "AES/$mode/$padding/$keyLength"
+        return if (operation == ENCRYPT) {
+            AesEncryptionException("Encrypt[$conf] - $msg", cause)
+        } else {
+            AesDecryptionException("Decrypt[$conf] - $msg", cause)
+        }
+    }
+
+    private val aesTransformation: String = "AES/$modeTransformation/$paddingTransformation"
+
+    private val modeTransformation: String
+        get() {
+            return when (mode) {
+                CBC -> "CBC"
+                CTR -> "CTR"
+                GCM -> "GCM"
+            }
+        }
+
+    private val paddingTransformation: String
+        get() {
+            return when (padding) {
+                PKCS5 -> "PKCS5Padding"
+                PKCS7 -> "PKCS5Padding" // Java uses PKCS5 constant even though it is technically PKCS7
+                null -> "NoPadding"
+            }
+        }
+
+    private fun getCipherMode(operation: Operation): Int {
+        return when (operation) {
+            DECRYPT -> Cipher.DECRYPT_MODE
+            ENCRYPT -> Cipher.ENCRYPT_MODE
+        }
+    }
+}


### PR DESCRIPTION
Add buffer and file wrapper around the native ciphers in order to call the native method in the right order. 
The File based implementation uses streams and their Ciphered version in order to perform the crypto operation by reading/writing the stream block by block