### PR TITLE
Aes engines

### DIFF
--- a/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesBufferEngine.kt
+++ b/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesBufferEngine.kt
@@ -1,0 +1,94 @@
+package com.island.yoshiz.mpp.krypto.aes.engines
+
+import com.island.yoshiz.mpp.krypto.aes.checks.AesSanityChecks
+import com.island.yoshiz.mpp.krypto.aes.ciphers.AesBufferCipher
+import com.island.yoshiz.mpp.krypto.aes.model.buffer.AesDecryptedData
+import com.island.yoshiz.mpp.krypto.aes.model.buffer.AesEncryptedData
+import com.island.yoshiz.mpp.krypto.aes.model.buffer.PlainData
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKey
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKeyIv
+import com.island.yoshiz.mpp.krypto.aes.model.keys.IV
+import com.island.yoshiz.mpp.krypto.aes.random.AesSecureRandom
+
+/**
+ * Offers several way to encrypt data. The recommended way would be to let this class generate the IV
+ * for you which will be returned as a result of the encrypted data. Offers as well ways to decrypt
+ */
+class AesBufferEngine internal constructor(
+        keyLength: AesKeysLength,
+        mode: AesBlockMode,
+        padding: Padding?,
+        private val inputChecks: AesSanityChecks,
+        private val secureGenerator: AesSecureRandom = AesSecureRandom(keyLength, mode),
+        private val bufferCipher: AesBufferCipher = AesBufferCipher(keyLength, mode, padding)
+) {
+
+
+    /**
+     * Encrypt the data with AES. Will securely generate an AES key of the right length and an IV of
+     * the correct length
+     *
+     * @param plainData     the data to encrypt
+     * @return the encrypted data
+     */
+    fun encrypt(plainData: PlainData): AesEncryptedData {
+        val keyIv = secureGenerator.generateAesKeyAndIv()
+        return encrypt(keyIv, plainData)
+    }
+
+    /**
+     * Encrypt the data with AES from the key submitted. It will securely generate an IV of the
+     * right length
+     *
+     * @param key           the key for the encryption
+     * @param plainData     the data to encrypt
+     * @return the encrypted data
+     */
+    fun encrypt(key: AesKey, plainData: PlainData): AesEncryptedData {
+        val iv = secureGenerator.generateIv()
+        return encrypt(AesKeyIv(iv, key), plainData)
+    }
+
+    /**
+     * This method is discouraged to use. It is kept for legacy purpose where you might need to
+     * decrypt the data manually and the use the method where either the IV [encrypt] or both the
+     * key and IV [encrypt] are generated for you.
+     */
+    fun encrypt(keyIv: AesKeyIv, plainData: PlainData): AesEncryptedData {
+        validateInputs(keyIv.aesKey, keyIv.iv)
+
+        val encryptedData = bufferCipher.encrypt(plainData, keyIv.iv.data, keyIv.aesKey.material)
+        return AesEncryptedData(keyIv.iv, keyIv.aesKey, encryptedData)
+    }
+
+    /**
+     * Decrypt the data with the submitted key and iv
+     *
+     * @param dataToDecrypt the encrypted data to decrypt and the IV
+     * @return decrypted data
+     */
+    fun decrypt(dataToDecrypt: AesEncryptedData): AesDecryptedData {
+        return decrypt(dataToDecrypt.encryptedData, dataToDecrypt.aesKey, dataToDecrypt.iv)
+    }
+
+    /**
+     * Decrypt the data with the submitted key and iv
+     *
+     * @param dataToDecrypt the encrypted data to decrypt and the IV
+     * @return decrypted data
+     */
+    fun decrypt(dataToDecrypt: ByteArray, aesKey: AesKey, iv: IV): AesDecryptedData {
+        validateInputs(aesKey, iv)
+
+        return bufferCipher.decrypt(dataToDecrypt, iv.data, aesKey.material)
+    }
+
+    private fun validateInputs(aesKey: AesKey, iv: IV) {
+        inputChecks.validateIv(iv)
+        inputChecks.validateAesKey(aesKey)
+    }
+}
+

--- a/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesEngineFactory.kt
+++ b/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesEngineFactory.kt
@@ -1,0 +1,49 @@
+package com.island.yoshiz.mpp.krypto.aes.engines
+
+import com.island.yoshiz.mpp.krypto.aes.checks.AesInputSanityCheck
+import com.island.yoshiz.mpp.krypto.aes.checks.AesInputSanityCheckNotSecure
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesConfiguration
+
+/**
+ * Entry point to generate [AesBufferEngine] or [AesFileEngine] from an [AesConfiguration].
+ * Non secure variant avoid exception throwing if IV are zeroed. This is provided only for legacy
+ * code compatibility
+ */
+class AesEngineFactory {
+
+    fun getAesBufferEngine(configuration: AesConfiguration): AesBufferEngine {
+        return AesBufferEngine(
+                configuration.keyLength,
+                configuration.mode,
+                configuration.padding,
+                AesInputSanityCheck(configuration.mode)
+        )
+    }
+
+    fun getNonSecureAesBufferEngine(configuration: AesConfiguration): AesBufferEngine {
+        return AesBufferEngine(
+                configuration.keyLength,
+                configuration.mode,
+                configuration.padding,
+                AesInputSanityCheckNotSecure(configuration.mode)
+        )
+    }
+
+    fun getAesFileEngine(configuration: AesConfiguration): AesFileEngine {
+        return AesFileEngine(
+                configuration.keyLength,
+                configuration.mode,
+                configuration.padding,
+                AesInputSanityCheck(configuration.mode)
+        )
+    }
+
+    fun getNonSecureAesFileEngine(configuration: AesConfiguration): AesBufferEngine {
+        return AesBufferEngine(
+                configuration.keyLength,
+                configuration.mode,
+                configuration.padding,
+                AesInputSanityCheckNotSecure(configuration.mode)
+        )
+    }
+}

--- a/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesFileEngine.kt
+++ b/aes/src/commonMain/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesFileEngine.kt
@@ -1,0 +1,229 @@
+package com.island.yoshiz.mpp.krypto.aes.engines
+
+import com.island.yoshiz.mpp.krypto.aes.checks.AesSanityChecks
+import com.island.yoshiz.mpp.krypto.aes.ciphers.AesFileCipher
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding
+import com.island.yoshiz.mpp.krypto.aes.model.file.AesDecryptedFileAndIV
+import com.island.yoshiz.mpp.krypto.aes.model.file.AesEncryptedFile
+import com.island.yoshiz.mpp.krypto.aes.model.file.AesEncryptedFileAndIV
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKey
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKeyIv
+import com.island.yoshiz.mpp.krypto.aes.model.keys.IV
+import com.island.yoshiz.mpp.krypto.aes.random.AesSecureRandom
+
+/**
+ * Offers several way to encrypt data. The recommended way would be to let this class generate the IV
+ * for you which will be returned as a result of the encrypted data. Offers as well ways to decrypt
+ */
+class AesFileEngine internal constructor(
+        keyLength: AesKeysLength,
+        mode: AesBlockMode,
+        padding: Padding?,
+        private val inputChecks: AesSanityChecks,
+        private val secureGenerator: AesSecureRandom = AesSecureRandom(keyLength, mode),
+        private val fileCipher: AesFileCipher = AesFileCipher(keyLength, mode, padding)
+) {
+
+
+    /**
+     * Encrypt the file with AES. Will securely generate an AES key of the right length and an IV of
+     * the correct length
+     *
+     * @param pathToFile the full path of the file to encrypt
+     * @param replaceOriginal true for the encrypted file to replace the original one
+     * @return the key, iv and the path to the encrypted file
+     */
+    fun encrypt(pathToFile: String, replaceOriginal: Boolean = true): AesEncryptedFileAndIV {
+        val keyIv = secureGenerator.generateAesKeyAndIv()
+        return encrypt(keyIv, pathToFile, replaceOriginal)
+    }
+
+    /**
+     * Encrypt the file with AES from the key submitted. It will securely generate an IV of the
+     * right length
+     *
+     * @param key           the key for the encryption
+     * @param pathToFile the full path of the file to encrypt
+     * @param replaceOriginal true for the encrypted file to replace the original one
+     * @return the key, iv and the path to the encrypted file
+     */
+    fun encrypt(
+            key: AesKey, pathToFile: String, replaceOriginal: Boolean = true
+    ): AesEncryptedFileAndIV {
+        val iv = secureGenerator.generateIv()
+        return encrypt(AesKeyIv(iv, key), pathToFile, replaceOriginal)
+    }
+
+    /**
+     * This method is discouraged to use. It is kept for legacy purpose where you might need to
+     * decrypt the data manually and the use the method where either the IV [encrypt] or both the
+     * key and IV [encrypt] are generated for you.
+     */
+    fun encrypt(
+            keyIv: AesKeyIv, pathToFile: String, replaceOriginal: Boolean = true
+    ): AesEncryptedFileAndIV {
+        validateInputs(keyIv.aesKey, keyIv.iv)
+
+        val encryptedFilePath = fileCipher.encrypt(
+                pathToFile,
+                keyIv.iv.data,
+                keyIv.aesKey.material,
+                replaceOriginal,
+                expectIvInFile = false
+        )
+
+        return AesEncryptedFileAndIV(keyIv, encryptedFilePath)
+    }
+
+    /**
+     * Encrypt the file with AES. Will securely generate an AES key of the right length and an IV of
+     * the correct length
+     *
+     * @param pathToFile the full path of the file to encrypt
+     * @param replaceOriginal true for the encrypted file to replace the original one
+     * @return the key, iv and the path to the encrypted file
+     */
+    fun encryptAddIv(pathToFile: String, replaceOriginal: Boolean = true): AesEncryptedFile {
+        val keyIv = secureGenerator.generateAesKeyAndIv()
+        return encryptAddIv(keyIv, pathToFile, replaceOriginal)
+    }
+
+    /**
+     * Encrypt the file with AES from the key submitted. It will securely generate an IV of the
+     * right length
+     *
+     * @param key           the key for the encryption
+     * @param pathToFile the full path of the file to encrypt
+     * @param replaceOriginal true for the encrypted file to replace the original one
+     * @return the key, iv and the path to the encrypted file
+     */
+    fun encryptAddIv(
+            key: AesKey, pathToFile: String, replaceOriginal: Boolean = true
+    ): AesEncryptedFile {
+        val iv = secureGenerator.generateIv()
+        return encryptAddIv(AesKeyIv(iv, key), pathToFile, replaceOriginal)
+    }
+
+    /**
+     * This method is discouraged to use. It is kept for legacy purpose where you might need to
+     * decrypt the data manually and the use the method where either the IV [encrypt] or both the
+     * key and IV [encrypt] are generated for you.
+     */
+    fun encryptAddIv(
+            keyIv: AesKeyIv, pathToFile: String, replaceOriginal: Boolean = true
+    ): AesEncryptedFile {
+        validateInputs(keyIv.aesKey, keyIv.iv)
+
+        val encryptedFilePath = fileCipher.encrypt(
+                pathToFile,
+                keyIv.iv.data,
+                keyIv.aesKey.material,
+                replaceOriginal,
+                expectIvInFile = false
+        )
+
+        return AesEncryptedFile(keyIv.aesKey, encryptedFilePath)
+    }
+
+    /**
+     * Encrypt the file with AES. Will securely generate an AES key of the right length and an IV of
+     * the correct length
+     *
+     * @param pathToFile the full path of the file to encrypt
+     * @param replaceOriginal true for the encrypted file to replace the original one
+     * @return the key, iv and the path to the encrypted file
+     */
+    fun encryptAddAndPersistIv(
+            pathToFile: String, replaceOriginal: Boolean = true
+    ): AesEncryptedFile {
+        val keyIv = secureGenerator.generateAesKeyAndIv()
+        return encryptAddIv(keyIv, pathToFile, replaceOriginal)
+    }
+
+    /**
+     * Encrypt the file with AES from the key submitted. It will securely generate an IV of the
+     * right length
+     *
+     * @param key           the key for the encryption
+     * @param pathToFile the full path of the file to encrypt
+     * @param replaceOriginal true for the encrypted file to replace the original one
+     * @return the key, iv and the path to the encrypted file
+     */
+    fun encryptAddAndPersistIv(
+            key: AesKey, pathToFile: String, replaceOriginal: Boolean = true
+    ): AesEncryptedFile {
+        val iv = secureGenerator.generateIv()
+        return encryptAddIv(AesKeyIv(iv, key), pathToFile, replaceOriginal)
+    }
+
+    /**
+     * This method is discouraged to use. It is kept for legacy purpose where you might need to
+     * decrypt the data manually and the use the method where either the IV [encrypt] or both the
+     * key and IV [encrypt] are generated for you.
+     */
+    fun encryptAddAndPersistIv(
+            keyIv: AesKeyIv, pathToFile: String, replaceOriginal: Boolean = true
+    ): AesEncryptedFile {
+        validateInputs(keyIv.aesKey, keyIv.iv)
+
+        val encryptedFilePath = fileCipher.encrypt(
+                pathToFile,
+                keyIv.iv.data,
+                keyIv.aesKey.material,
+                replaceOriginal,
+                expectIvInFile = true
+        )
+
+        return AesEncryptedFile(keyIv.aesKey, encryptedFilePath)
+    }
+
+    /**
+     * Decrypt the data with the submitted key and iv
+     *
+     * @param fileToDecrypt the encrypted data to decrypt and the IV
+     * @return decrypted data
+     */
+    fun decrypt(
+            fileToDecrypt: AesEncryptedFileAndIV, replaceOriginal: Boolean
+    ): AesDecryptedFileAndIV {
+        validateInputs(fileToDecrypt.keyIv.aesKey, fileToDecrypt.keyIv.iv)
+
+        val path = fileCipher.decrypt(
+                fileToDecrypt.pathToFile,
+                fileToDecrypt.keyIv.iv.data,
+                fileToDecrypt.keyIv.aesKey.material,
+                replaceOriginal,
+                expectIvInFile = false
+        )
+        return AesDecryptedFileAndIV(fileToDecrypt.keyIv, path)
+    }
+
+    /**
+     * Decrypt the data with the submitted key and iv
+     *
+     * @param fileToDecrypt the encrypted data to decrypt and the IV
+     * @return decrypted data
+     */
+    fun decryptWithIvFromFile(
+            fileToDecrypt: AesEncryptedFileAndIV, replaceOriginal: Boolean
+    ): AesDecryptedFileAndIV {
+        validateInputs(fileToDecrypt.keyIv.aesKey, fileToDecrypt.keyIv.iv)
+
+        val path = fileCipher.decrypt(
+                fileToDecrypt.pathToFile,
+                fileToDecrypt.keyIv.iv.data,
+                fileToDecrypt.keyIv.aesKey.material,
+                replaceOriginal,
+                expectIvInFile = true
+        )
+        return AesDecryptedFileAndIV(fileToDecrypt.keyIv, path)
+    }
+
+    private fun validateInputs(aesKey: AesKey, iv: IV) {
+        inputChecks.validateIv(iv)
+        inputChecks.validateAesKey(aesKey)
+    }
+}
+

--- a/aes/src/jvmTest/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesBufferEngineTest.kt
+++ b/aes/src/jvmTest/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesBufferEngineTest.kt
@@ -1,0 +1,195 @@
+package com.island.yoshiz.mpp.krypto.aes.engines
+
+import com.island.yoshiz.mpp.krypto.ENCRYPTION_KEY_B64
+import com.island.yoshiz.mpp.krypto.IV_B64
+import com.island.yoshiz.mpp.krypto.MESSAGE_LONG
+import com.island.yoshiz.mpp.krypto.MESSAGE_LONG_ENCRYPTED_B64
+import com.island.yoshiz.mpp.krypto.aes.checks.AesInputSanityCheck
+import com.island.yoshiz.mpp.krypto.aes.ciphers.AesBufferCipher
+import com.island.yoshiz.mpp.krypto.aes.model.buffer.AesEncryptedData
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode.CBC
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength.Aes256
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding.PKCS7
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesInvalidIvException
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesInvalidKeyException
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKey
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKeyIv
+import com.island.yoshiz.mpp.krypto.aes.model.keys.IV
+import com.island.yoshiz.mpp.krypto.aes.random.AesSecureRandom
+import com.island.yoshiz.mpp.krypto.common.utils.Base64Factory
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlin.test.*
+
+@ExperimentalStdlibApi
+internal class AesBufferEngineTest {
+
+    private lateinit var engine: AesBufferEngine
+
+    @MockK
+    private lateinit var inputChecksMock: AesInputSanityCheck
+
+    @MockK
+    private lateinit var randomGeneratorMock: AesSecureRandom
+
+    @MockK
+    private lateinit var aesBufferCipherMock: AesBufferCipher
+
+    private val base64Engine = Base64Factory.createEngine()
+    private val aesKey = AesKey(base64Engine.decode(ENCRYPTION_KEY_B64))
+    private val iv = IV(base64Engine.decode(IV_B64))
+    private val aesKeyIv = AesKeyIv(iv, aesKey)
+
+    private val msgPlain = MESSAGE_LONG.encodeToByteArray()
+    private val msgEncrypted = MESSAGE_LONG_ENCRYPTED_B64.encodeToByteArray()
+
+    private val encryptedData = AesEncryptedData(iv, aesKey, msgEncrypted)
+
+    @BeforeTest
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        engine = AesBufferEngine(
+                Aes256,
+                CBC,
+                PKCS7,
+                inputChecksMock,
+                randomGeneratorMock,
+                aesBufferCipherMock)
+
+        every { randomGeneratorMock.generateAesKey() } returns aesKey
+        every { randomGeneratorMock.generateIv() } returns iv
+        every { randomGeneratorMock.generateAesKeyAndIv() } returns aesKeyIv
+
+        every { inputChecksMock.validateAesKey(aesKey) } returns Unit
+        every { inputChecksMock.validateIv(iv) } returns Unit
+
+        every { aesBufferCipherMock.encrypt(msgPlain,iv.data,aesKey.material) } returns msgEncrypted
+        every { aesBufferCipherMock.decrypt(msgEncrypted,iv.data,aesKey.material) } returns msgPlain
+    }
+
+    @Test
+    fun givenEncryptPlainData_andNoKeyOrIv_thenKeyIvEncryptedDataGenerated() {
+
+        engine.encrypt(msgPlain)
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify { aesBufferCipherMock.encrypt(msgPlain,iv.data,aesKey.material) }
+
+        verify { randomGeneratorMock.generateAesKeyAndIv() }
+    }
+
+    @Test
+    fun givenEncryptPlainData_andCheckInvalidIv_thenThrowAesInvalidIvException() {
+        every { inputChecksMock.validateIv(iv) } throws AesInvalidIvException("invalid IV")
+
+        assertFailsWith(AesInvalidIvException::class) {
+            engine.encrypt(msgPlain)
+        }
+
+        verify { inputChecksMock.validateIv(iv) }
+
+        verify(exactly = 0) { inputChecksMock.validateAesKey(aesKey) }
+        verify(exactly = 0) { aesBufferCipherMock.encrypt(msgPlain,iv.data,aesKey.material) }
+
+        verify { randomGeneratorMock.generateAesKeyAndIv() }
+    }
+
+    @Test
+    fun givenEncryptPlainData_andCheckInvalidAesKey_thenThrowAesInvalidKeyException() {
+        every { inputChecksMock.validateAesKey(aesKey) } throws AesInvalidKeyException("invalid AesKey")
+
+        assertFailsWith(AesInvalidKeyException::class) {
+            engine.encrypt(msgPlain)
+        }
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify(exactly = 0) { aesBufferCipherMock.encrypt(msgPlain,iv.data,aesKey.material) }
+
+        verify { randomGeneratorMock.generateAesKeyAndIv() }
+    }
+
+    @Test
+    fun givenEncryptPlainData_andKeySubmitted_thenIvEncryptedDataGenerated() {
+        engine.encrypt(aesKey, msgPlain)
+
+        verify { randomGeneratorMock.generateIv() }
+        verify(exactly = 0) { randomGeneratorMock.generateAesKey() }
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify { aesBufferCipherMock.encrypt(msgPlain,iv.data,aesKey.material) }
+    }
+
+    @Test
+    fun givenEncryptPlainData_andInvalidIv_thenThrowAesInvalidIvException() {
+        every { inputChecksMock.validateIv(iv) } throws AesInvalidIvException("invalid IV")
+
+        assertFailsWith(AesInvalidIvException::class) {
+            engine.encrypt(aesKey, msgPlain)
+        }
+
+        verify { randomGeneratorMock.generateIv() }
+        verify { inputChecksMock.validateIv(iv) }
+        verify(exactly = 0) { randomGeneratorMock.generateAesKey() }
+
+        verify(exactly = 0) { inputChecksMock.validateAesKey(aesKey) }
+        verify(exactly = 0) { aesBufferCipherMock.encrypt(msgPlain,iv.data,aesKey.material) }
+    }
+
+    @Test
+    fun givenEncryptPlainData_andKeyIvSubmitted_thenKeyIvEncryptedDataGenerated() {
+        engine.encrypt(aesKeyIv, msgPlain)
+
+        verify(exactly = 0) { randomGeneratorMock.generateIv() }
+        verify(exactly = 0) { randomGeneratorMock.generateAesKey() }
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify { aesBufferCipherMock.encrypt(msgPlain,iv.data,aesKey.material) }
+    }
+
+    @Test
+    fun givenDecryptEncryptedData_andCorrectParams_thenReturnDecryptedData() {
+        engine.decrypt(encryptedData)
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify { aesBufferCipherMock.decrypt(msgEncrypted,iv.data,aesKey.material) }
+    }
+
+    @Test
+    fun givenDecryptEncryptedData_andInavlidIv_thenThrowAesInvalidIvException() {
+        every { inputChecksMock.validateIv(iv) } throws AesInvalidIvException("invalid IV")
+
+        assertFailsWith(AesInvalidIvException::class) {
+            engine.decrypt(encryptedData)
+        }
+
+        verify { inputChecksMock.validateIv(iv) }
+
+        verify(exactly = 0) { inputChecksMock.validateAesKey(aesKey) }
+        verify(exactly = 0) { aesBufferCipherMock.decrypt(msgEncrypted,iv.data,aesKey.material) }
+    }
+
+    @Test
+    fun givenDecryptEncryptedData_andInavlidAesKey_thenThrowAesInvalidKeyException() {
+        every { inputChecksMock.validateAesKey(aesKey) } throws AesInvalidKeyException("invalid key")
+
+        assertFailsWith(AesInvalidKeyException::class) {
+            engine.decrypt(encryptedData)
+        }
+
+        verify(exactly = 0) { aesBufferCipherMock.decrypt(msgEncrypted,iv.data,aesKey.material) }
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+    }
+}

--- a/aes/src/jvmTest/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesFileEngineTest.kt
+++ b/aes/src/jvmTest/kotlin/com/island/yoshiz/mpp/krypto/aes/engines/AesFileEngineTest.kt
@@ -1,0 +1,323 @@
+package com.island.yoshiz.mpp.krypto.aes.engines
+
+import com.island.yoshiz.mpp.krypto.ENCRYPTION_KEY_B64
+import com.island.yoshiz.mpp.krypto.IV_B64
+import com.island.yoshiz.mpp.krypto.aes.checks.AesInputSanityCheck
+import com.island.yoshiz.mpp.krypto.aes.ciphers.AesFileCipher
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesBlockMode.CBC
+import com.island.yoshiz.mpp.krypto.aes.model.config.AesKeysLength.Aes256
+import com.island.yoshiz.mpp.krypto.aes.model.config.Padding.PKCS7
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesInvalidIvException
+import com.island.yoshiz.mpp.krypto.aes.model.exceptions.AesInvalidKeyException
+import com.island.yoshiz.mpp.krypto.aes.model.file.AesEncryptedFileAndIV
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKey
+import com.island.yoshiz.mpp.krypto.aes.model.keys.AesKeyIv
+import com.island.yoshiz.mpp.krypto.aes.model.keys.IV
+import com.island.yoshiz.mpp.krypto.aes.random.AesSecureRandom
+import com.island.yoshiz.mpp.krypto.common.utils.Base64Factory
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlin.test.*
+
+@ExperimentalStdlibApi
+internal class AesFileEngineTest {
+
+    private lateinit var engine: AesFileEngine
+
+    @MockK
+    private lateinit var inputChecksMock: AesInputSanityCheck
+
+    @MockK
+    private lateinit var randomGeneratorMock: AesSecureRandom
+
+    @MockK
+    private lateinit var aesFileCipherMock: AesFileCipher
+
+    private val base64Engine = Base64Factory.createEngine()
+    private val aesKey = AesKey(base64Engine.decode(ENCRYPTION_KEY_B64))
+    private val iv = IV(base64Engine.decode(IV_B64))
+    private val aesKeyIv = AesKeyIv(iv, aesKey)
+
+    private val decryptedFlePath = "decrypted_file"
+    private val encryptedFlePath = "encrypted_file"
+
+    private val encryptedFile = AesEncryptedFileAndIV(aesKeyIv, encryptedFlePath)
+
+    @BeforeTest
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        engine = AesFileEngine(
+                Aes256,
+                CBC,
+                PKCS7,
+                inputChecksMock,
+                randomGeneratorMock,
+                aesFileCipherMock
+        )
+
+        every { randomGeneratorMock.generateAesKey() } returns aesKey
+        every { randomGeneratorMock.generateIv() } returns iv
+        every { randomGeneratorMock.generateAesKeyAndIv() } returns aesKeyIv
+
+        every { inputChecksMock.validateAesKey(aesKey) } returns Unit
+        every { inputChecksMock.validateIv(iv) } returns Unit
+
+        every {
+            aesFileCipherMock.encrypt(
+                    eq(decryptedFlePath),
+                    eq(iv.data),
+                    eq(aesKey.material),
+                    any(),
+                    any()
+            )
+        } returns encryptedFlePath
+
+        every {
+            aesFileCipherMock.decrypt(
+                    eq(encryptedFlePath),
+                    eq(iv.data),
+                    eq(aesKey.material),
+                    any(),
+                    any()
+            )
+        } returns decryptedFlePath
+    }
+
+    @Test
+    fun givenEncryptFile_andNoKeyOrIv_andReplace_thenKeyIvEncryptedDataGenerated() {
+
+        val result = engine.encrypt(decryptedFlePath, true)
+
+        assertEquals(aesKeyIv, result.keyIv)
+        assertEquals(encryptedFlePath, result.pathToFile)
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify {
+            aesFileCipherMock.encrypt(
+                    decryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+
+        verify { randomGeneratorMock.generateAesKeyAndIv() }
+    }
+
+    @Test
+    fun givenEncryptFile_andCheckInvalidIv_andReplace_thenThrowAesInvalidIvException() {
+        every { inputChecksMock.validateIv(iv) } throws AesInvalidIvException("invalid IV")
+
+        assertFailsWith(AesInvalidIvException::class) {
+            engine.encrypt(decryptedFlePath, true)
+        }
+
+        verify { inputChecksMock.validateIv(iv) }
+
+        verify(exactly = 0) { inputChecksMock.validateAesKey(aesKey) }
+        verify(exactly = 0) {
+            aesFileCipherMock.encrypt(
+                    decryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+
+        verify { randomGeneratorMock.generateAesKeyAndIv() }
+    }
+
+    @Test
+    fun givenEncryptFile_andCheckInvalidAesKey_andReplace_thenThrowAesInvalidKeyException() {
+        every { inputChecksMock.validateAesKey(aesKey) } throws AesInvalidKeyException("invalid AesKey")
+
+        assertFailsWith(AesInvalidKeyException::class) {
+            engine.encrypt(decryptedFlePath, true)
+        }
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify(exactly = 0) {
+            aesFileCipherMock.encrypt(
+                    decryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+
+        verify { randomGeneratorMock.generateAesKeyAndIv() }
+    }
+
+    @Test
+    fun givenEncryptFile_andKeySubmitted_andReplace_thenIvEncryptedDataGenerated() {
+
+        val result = engine.encrypt(aesKey, decryptedFlePath, true)
+
+        assertEquals(aesKeyIv, result.keyIv)
+        assertEquals(encryptedFlePath, result.pathToFile)
+
+        verify { randomGeneratorMock.generateIv() }
+        verify(exactly = 0) { randomGeneratorMock.generateAesKey() }
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify {
+            aesFileCipherMock.encrypt(
+                    decryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+    }
+
+    @Test
+    fun givenEncryptFile_andInvalidIv_andReplace_thenThrowAesInvalidIvException() {
+        every { inputChecksMock.validateIv(iv) } throws AesInvalidIvException("invalid IV")
+
+        assertFailsWith(AesInvalidIvException::class) {
+            engine.encrypt(aesKey, decryptedFlePath, true)
+        }
+
+        verify { randomGeneratorMock.generateIv() }
+        verify { inputChecksMock.validateIv(iv) }
+        verify(exactly = 0) { randomGeneratorMock.generateAesKey() }
+
+        verify(exactly = 0) { inputChecksMock.validateAesKey(aesKey) }
+        verify(exactly = 0) {
+            aesFileCipherMock.encrypt(
+                    decryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+    }
+
+    @Test
+    fun givenEncryptFile_andKeyIvSubmitted_andReplace_thenKeyIvEncryptedDataGenerated() {
+        val result = engine.encrypt(aesKeyIv, decryptedFlePath, true)
+
+        assertEquals(aesKeyIv, result.keyIv)
+        assertEquals(encryptedFlePath, result.pathToFile)
+
+        verify(exactly = 0) { randomGeneratorMock.generateIv() }
+        verify(exactly = 0) { randomGeneratorMock.generateAesKey() }
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify {
+            aesFileCipherMock.encrypt(
+                    decryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+    }
+
+    @Test
+    fun givenDecryptFile_andCorrectParams_andReplace_thenReturnDecryptedData() {
+        val result = engine.decrypt(encryptedFile, true)
+
+        assertEquals(aesKeyIv, result.keyIv)
+        assertEquals(decryptedFlePath, result.pathToFile)
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify {
+            aesFileCipherMock.decrypt(
+                    encryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+    }
+
+    @Test
+    fun givenDecryptFile_andInvalidIv_andReplace_thenThrowAesInvalidIvException() {
+        every { inputChecksMock.validateIv(iv) } throws AesInvalidIvException("invalid IV")
+
+        assertFailsWith(AesInvalidIvException::class) {
+            engine.decrypt(encryptedFile, true)
+        }
+
+        verify { inputChecksMock.validateIv(iv) }
+
+        verify(exactly = 0) { inputChecksMock.validateAesKey(aesKey) }
+        verify(exactly = 0) {
+            aesFileCipherMock.decrypt(
+                    encryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+    }
+
+    @Test
+    fun givenDecryptFile_andInvalidAesKey_andReplace_thenThrowAesInvalidKeyException() {
+        every { inputChecksMock.validateAesKey(aesKey) } throws AesInvalidKeyException("invalid key")
+
+        assertFailsWith(AesInvalidKeyException::class) {
+            engine.decrypt(encryptedFile, true)
+        }
+
+        verify(exactly = 0) {
+            aesFileCipherMock.decrypt(
+                    encryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = false
+            )
+        }
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+    }
+
+    @Test
+    fun givenDecryptFile_andCorrectParams_andNotReplace_thenReturnDecryptedData() {
+        val result = engine.decrypt(encryptedFile, false)
+
+        assertEquals(aesKeyIv, result.keyIv)
+        assertEquals(decryptedFlePath, result.pathToFile)
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify {
+            aesFileCipherMock.decrypt(
+                    encryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = false, expectIvInFile = false
+            )
+        }
+    }
+
+    @Test
+    fun givenDecryptFile_andCorrectParams_andNotReplace_andPersistIv_thenReturnDecryptedData() {
+        val result = engine.decryptWithIvFromFile(encryptedFile, false)
+
+        assertEquals(aesKeyIv, result.keyIv)
+        assertEquals(decryptedFlePath, result.pathToFile)
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify {
+            aesFileCipherMock.decrypt(
+                    encryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = false, expectIvInFile = true
+            )
+        }
+    }
+
+    @Test
+    fun givenDecryptFile_andCorrectParams_andReplace_andPersistIv_thenReturnDecryptedData() {
+        val result = engine.decryptWithIvFromFile(encryptedFile, true)
+
+        assertEquals(aesKeyIv, result.keyIv)
+        assertEquals(decryptedFlePath, result.pathToFile)
+
+        verify { inputChecksMock.validateIv(iv) }
+        verify { inputChecksMock.validateAesKey(aesKey) }
+
+        verify {
+            aesFileCipherMock.decrypt(
+                    encryptedFlePath, iv.data, aesKey.material,
+                    replaceOriginal = true, expectIvInFile = true
+            )
+        }
+    }
+}


### PR DESCRIPTION
Add engines: wrapped buffer and file ciphers in order to allow methods that don't require key and or IV. In which case it will be generated internally via the secure random generator.
Also a factory is added in order to preserve internal structure and construction detail 'hidden'